### PR TITLE
Prevent warning from being printed in gpg2.1

### DIFF
--- a/lib/Horde/Crypt/Pgp/Backend/Binary.php
+++ b/lib/Horde/Crypt/Pgp/Backend/Binary.php
@@ -789,6 +789,9 @@ extends Horde_Crypt_Pgp_Backend
             return '--keyring ' . $this->_publicKeyring;
 
         case 'private':
+            if ($this->_gnupg21) {
+                return '';
+            }
             if (empty($this->_privateKeyring)) {
                 $this->_privateKeyring = $this->_createTempFile('horde-pgp');
             }


### PR DESCRIPTION
The ignored --secret-keyring option causes a warning to be printed
to the user.

See: https://dev.gnupg.org/T2749