### PR TITLE
lib/Horde/Crypt/Pgp.php: Shorten long PGP key IDs to 16 digits (inste…

### DIFF
--- a/lib/Horde/Crypt/Pgp.php
+++ b/lib/Horde/Crypt/Pgp.php
@@ -268,8 +268,8 @@ class Horde_Crypt_Pgp extends Horde_Crypt
         if (strpos($keyid, '0x') === 0) {
             $keyid = substr($keyid, 2);
         }
-        if (strlen($keyid) > 8) {
-            $keyid = substr($keyid, -8);
+        if (strlen($keyid) > 16) {
+            $keyid = substr($keyid, -16);
         }
         return '0x' . $keyid;
     }


### PR DESCRIPTION
…ad of deprecated 8 digits).

 Newer keyserver implementations return a "400 Bad Request" error if
 8-digit-key-IDs are queried (e.g. keys.openpgp.org).