### PR TITLE
support parsing public keys with just an email

### DIFF
--- a/lib/Horde/Crypt/Pgp/Backend/Binary.php
+++ b/lib/Horde/Crypt/Pgp/Backend/Binary.php
@@ -284,7 +284,7 @@ extends Horde_Crypt_Pgp_Backend
                 if (strpos($lowerLine, ':user id packet:') !== false) {
                     $uid_idx++;
                     $line = preg_replace_callback('/\\\\x([0-9a-f]{2})/', $packetInfoHelper, $line);
-                    if (!preg_match('/"([^\<]+)\<([^\>]+)\>"/', $line, $matches)) {
+                    if (!preg_match('/"([^\<]+)\<([^\>]+)\>"/', $line, $matches) && !preg_match('/"([^\<]+@[^\>]+)"/', $line, $matches)) {
                         continue;
                     }
                     $header = 'id' . $uid_idx;
@@ -308,7 +308,11 @@ extends Horde_Crypt_Pgp_Backend
                             $keyid = substr(str_replace(' ', '', $m[1]), -16);
                         }
                     }
-                    $out[$key_idx]['signature'][$header]['email'] = $matches[2];
+                    if (array_key_exists(2,$matches)) {
+                      $out[$key_idx]['signature'][$header]['email'] = $matches[2];
+                    } else {
+                      $out[$key_idx]['signature'][$header]['email'] = $matches[1];
+                    }
                     $out[$key_idx]['signature'][$header]['keyid'] = $keyid;
                     continue;
                 }


### PR DESCRIPTION
Various modern clients start creating keys with just the email- address as the string in the uid packet.

If we do not find an RFC-2822 style mail name-addr, we assume the user id is just the emailaddress and use it as name and email.