### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Crypt/Pgp.php
+++ b/lib/Horde/Crypt/Pgp.php
@@ -244,8 +244,8 @@ class Horde_Crypt_Pgp extends Horde_Crypt
 
             $msg .= $leftrow[0] . (isset($key['name']) ? stripcslashes($key['name']) : '') . "\n"
                 . $leftrow[1] . (($key['key_type'] == 'public_key') ? Horde_Crypt_Translation::t("Public Key") : Horde_Crypt_Translation::t("Private Key")) . "\n"
-                . $leftrow[2] . strftime("%D", $val[$sig_key]['created']) . "\n"
-                . $leftrow[3] . (empty($val[$sig_key]['expires']) ? '[' . Horde_Crypt_Translation::t("Never") . ']' : strftime("%D", $val[$sig_key]['expires'])) . "\n"
+                . $leftrow[2] . date("m/d/y", $val[$sig_key]['created']) . "\n"
+                . $leftrow[3] . (empty($val[$sig_key]['expires']) ? '[' . Horde_Crypt_Translation::t("Never") . ']' : date("m/d/y", $val[$sig_key]['expires'])) . "\n"
                 . $leftrow[4] . $key['key_size'] . " Bytes\n"
                 . $leftrow[5] . (empty($key['comment']) ? '[' . Horde_Crypt_Translation::t("None") . ']' : $key['comment']) . "\n"
                 . $leftrow[6] . (empty($key['email']) ? '[' . Horde_Crypt_Translation::t("None") . ']' : $key['email']) . "\n"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Crypt/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Crypt/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Crypt Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Crypt/Pgp/TestBase.php
+++ b/test/Horde/Crypt/Pgp/TestBase.php
@@ -18,13 +18,13 @@ extends Horde_Test_Case
     /* Returns the list of backends to test. */
     abstract protected function _setUp();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         @date_default_timezone_set('GMT');
         $this->_language = getenv('LANGUAGE');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         putenv('LANGUAGE=' . $this->_language);
     }

--- a/test/Horde/Crypt/PgpKeyserverTest.php
+++ b/test/Horde/Crypt/PgpKeyserverTest.php
@@ -14,7 +14,7 @@ class Horde_Crypt_PgpKeyserverTest extends Horde_Test_Case
     protected $_ks;
     protected $_gnupg;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $c = self::getConfig('CRYPT_TEST_CONFIG', __DIR__);
         $this->_gnupg = isset($c['gnupg'])
@@ -37,6 +37,8 @@ class Horde_Crypt_PgpKeyserverTest extends Horde_Test_Case
 
     public function testKeyserverRetrieve()
     {
+        $this->expectNotToPerformAssertions();
+
         try {
             $this->_ks->get('4DE5B969');
         } catch (Horde_Crypt_Exception $e) {

--- a/test/Horde/Crypt/PgpParseTest.php
+++ b/test/Horde/Crypt/PgpParseTest.php
@@ -12,7 +12,7 @@ class Horde_Crypt_PgpParseTest extends Horde_Test_Case
 {
     protected $_pgp;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_pgp = new Horde_Crypt_Pgp();
     }

--- a/test/Horde/Crypt/SmimeTest.php
+++ b/test/Horde/Crypt/SmimeTest.php
@@ -12,7 +12,7 @@
 
 class Horde_Crypt_SmimeTest extends Horde_Test_Case
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!extension_loaded('openssl')) {
             $this->markTestSkipped('No openssl support in PHP.');

--- a/test/Horde/Crypt/phpunit.xml
+++ b/test/Horde/Crypt/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: phpunit 8.x+9.x https://salsa.debian.org/horde-team/php-horde-crypt/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix the warning "Function strftime() is deprecated" https://salsa.debian.org/horde-team/php-horde-crypt/-/blob/debian-sid/debian/patches/2050_fix_php8.1.warning.patch
