### PR TITLE
make Smime::verifyPassphrase compatibe with php8

### DIFF
--- a/lib/Horde/Crypt/Smime.php
+++ b/lib/Horde/Crypt/Smime.php
@@ -50,7 +50,7 @@ class Horde_Crypt_Smime extends Horde_Crypt
             ? openssl_pkey_get_private($private_key)
             : openssl_pkey_get_private($private_key, $passphrase);
 
-        return is_resource($res);
+        return boolval($res);
     }
 
     /**


### PR DESCRIPTION
 `openssl_pkey_get_private` returns an instance of `OpenSSLAsymmetricKey` in php8. So we can't use `is_resource` anymore to check if it was successfull.

This still works with php74, since `boolval($someResource)` is always `true`.